### PR TITLE
Chore: update video_file to input_file & update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ make install
 2. Run the CLI (simple example):
 
 ```bash
-uv run python main.py -k $OPENAI_API_KEY path/to/video.mp4
+uv run python main.py -k $OPENAI_API_KEY path/to/input.mp4
 ```
 
 CLI options
- - `video_file`: positional path to the input video file
+ - `input_file`: positional path to the input video file
  - `-k, --api-key`: OpenAI API key (or set `OPENAI_API_KEY` env var)
- - `-o, --output-audio`: path for extracted audio file (defaults to video name with `.mp3`)
+ - `-o, --output-audio`: path for extracted audio file (defaults to input name with `.mp3` & fails if input is audio)
  - `-s, --save-transcript`: path to save the transcript (will ensure `.txt` extension)
  - `-f, --force`: re-extract audio even if it already exists
  - `--delete-audio`: delete audio files after transcription (default is to keep them)

--- a/tests/test_audio_management.py
+++ b/tests/test_audio_management.py
@@ -262,7 +262,7 @@ class TestTranscribeWithKeepAudio:
                 audio_path.write_text("x" * 1024)
 
                 with (
-                    patch.object(VideoTranscriber, "validate_video_file", return_value=video_path),
+                    patch.object(VideoTranscriber, "validate_input_file", return_value=video_path),
                     patch.object(VideoTranscriber, "extract_audio"),
                     patch("builtins.print"),
                 ):
@@ -289,7 +289,7 @@ class TestTranscribeWithKeepAudio:
                 audio_path.write_text("x" * 1024)
 
                 with (
-                    patch.object(VideoTranscriber, "validate_video_file", return_value=video_path),
+                    patch.object(VideoTranscriber, "validate_input_file", return_value=video_path),
                     patch.object(VideoTranscriber, "extract_audio"),
                     patch("builtins.print"),
                 ):
@@ -324,7 +324,7 @@ class TestTranscribeLargeWithKeepAudio:
                 chunk1.write_text("c1")
 
                 with (
-                    patch.object(VideoTranscriber, "validate_video_file", return_value=video_path),
+                    patch.object(VideoTranscriber, "validate_input_file", return_value=video_path),
                     patch.object(VideoTranscriber, "extract_audio"),
                     patch.object(VideoTranscriber, "get_audio_duration", return_value=600.0),
                     patch.object(VideoTranscriber, "extract_audio_chunk") as mock_extract,
@@ -358,7 +358,7 @@ class TestTranscribeLargeWithKeepAudio:
                 chunk1.write_text("c1")
 
                 with (
-                    patch.object(VideoTranscriber, "validate_video_file", return_value=video_path),
+                    patch.object(VideoTranscriber, "validate_input_file", return_value=video_path),
                     patch.object(VideoTranscriber, "extract_audio"),
                     patch.object(VideoTranscriber, "get_audio_duration", return_value=600.0),
                     patch.object(VideoTranscriber, "extract_audio_chunk") as mock_extract,
@@ -397,7 +397,7 @@ class TestTranscribeLargeWithKeepAudio:
                     chunk1.write_text("c1")
 
                     with (
-                        patch.object(VideoTranscriber, "validate_video_file", return_value=video_path),
+                        patch.object(VideoTranscriber, "validate_input_file", return_value=video_path),
                         patch.object(VideoTranscriber, "extract_audio"),
                         patch.object(VideoTranscriber, "get_audio_duration", return_value=600.0),
                         patch.object(VideoTranscriber, "extract_audio_chunk") as mock_extract,
@@ -421,7 +421,11 @@ class TestForceOverwriteWithExistingChunks:
             # Given existing audio and chunk files
             mock_client = MagicMock()
             mock_openai.return_value = mock_client
-            mock_client.audio.transcriptions.create.return_value = cast("TranscriptionVerbose", "new_transcript")  # type: ignore[arg-type]
+            mock_client.audio.transcriptions.create.return_value = cast(
+                # type: ignore[arg-type]
+                "TranscriptionVerbose",
+                "new_transcript",
+            )
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 video_path = Path(tmpdir) / "video.mp4"
@@ -434,7 +438,7 @@ class TestForceOverwriteWithExistingChunks:
                 old_chunk1.write_text("old_chunk1")
 
                 with (
-                    patch.object(VideoTranscriber, "validate_video_file", return_value=video_path),
+                    patch.object(VideoTranscriber, "validate_input_file", return_value=video_path),
                     patch.object(VideoTranscriber, "extract_audio") as mock_extract,
                     patch("builtins.print"),
                 ):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,8 +57,8 @@ class TestValidateVideoFile:
 
             with patch("vtt.main.OpenAI"):
                 transcriber = VideoTranscriber("key")
-                # When validate_video_file is called with existing file
-                result = transcriber.validate_video_file(video_path)
+                # When validate_input_file is called with existing file
+                result = transcriber.validate_input_file(video_path)
                 # Then same path is returned
                 assert result == video_path
 
@@ -69,11 +69,11 @@ class TestValidateVideoFile:
             transcriber = VideoTranscriber("key")
             nonexistent = Path("/nonexistent/video.mp4")
 
-            # When validate_video_file is called with non-existent file
+            # When validate_input_file is called with non-existent file
             with pytest.raises(FileNotFoundError) as exc_info:
-                transcriber.validate_video_file(nonexistent)
+                transcriber.validate_input_file(nonexistent)
             # Then FileNotFoundError is raised with appropriate message
-            assert "Video file not found" in str(exc_info.value)
+            assert "Input file not found" in str(exc_info.value)
 
 
 class TestResolveAudioPath:
@@ -385,7 +385,11 @@ class TestTranscribeAudioFile:
         with patch("vtt.main.OpenAI") as mock_openai:
             mock_client = MagicMock()
             mock_openai.return_value = mock_client
-            mock_client.audio.transcriptions.create.return_value = cast("TranscriptionVerbose", "Hello world")  # type: ignore[arg-type]
+            mock_client.audio.transcriptions.create.return_value = cast(
+                # type: ignore[arg-type]
+                "TranscriptionVerbose",
+                "Hello world",
+            )
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 audio_path = Path(tmpdir) / "audio.mp3"
@@ -412,7 +416,11 @@ class TestDirectAudioTranscription:
         with patch("vtt.main.OpenAI") as mock_openai:
             mock_client = MagicMock()
             mock_openai.return_value = mock_client
-            mock_client.audio.transcriptions.create.return_value = cast("TranscriptionVerbose", "Test transcript")  # type: ignore[arg-type]
+            mock_client.audio.transcriptions.create.return_value = cast(
+                # type: ignore[arg-type]
+                "TranscriptionVerbose",
+                "Test transcript",
+            )
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 input_audio = Path(tmpdir) / "input_audio.mp3"
@@ -434,7 +442,11 @@ class TestDirectAudioTranscription:
         with patch("vtt.main.OpenAI") as mock_openai:
             mock_client = MagicMock()
             mock_openai.return_value = mock_client
-            mock_client.audio.transcriptions.create.return_value = cast("TranscriptionVerbose", "Chunk transcript")  # type: ignore[arg-type]
+            mock_client.audio.transcriptions.create.return_value = cast(
+                # type: ignore[arg-type]
+                "TranscriptionVerbose",
+                "Chunk transcript",
+            )
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 chunk_file = Path(tmpdir) / "audio_chunk0.mp3"
@@ -505,7 +517,12 @@ class TestDirectAudioTranscription:
                     transcriber = VideoTranscriber("key")
 
                     # When transcribe is called with scan_chunks=True
-                    result = transcriber.transcribe(chunk0, audio_path=None, scan_chunks=True)  # type: ignore[call-arg]
+                    result = transcriber.transcribe(
+                        # type: ignore[call-arg]
+                        chunk0,
+                        audio_path=None,
+                        scan_chunks=True,
+                    )
 
                     # Then all 3 chunks are transcribed in order
                     assert mock_client.audio.transcriptions.create.call_count == 3
@@ -534,11 +551,17 @@ class TestDirectAudioTranscription:
                     transcriber = VideoTranscriber("key")
 
                     # When transcribe is called with scan_chunks=True
-                    result = transcriber.transcribe(chunk0, audio_path=None, scan_chunks=True)  # type: ignore[call-arg]
+                    result = transcriber.transcribe(
+                        # type: ignore[call-arg]
+                        chunk0,
+                        audio_path=None,
+                        scan_chunks=True,
+                    )
 
                     # Then timestamps are shifted and chunks separated with blank lines
                     assert "[00:00 - 00:02]" in result  # First chunk at 0s
-                    assert "[00:10 - 00:12]" in result  # Second chunk offset by 10s
+                    # Second chunk offset by 10s
+                    assert "[00:10 - 00:12]" in result
                     assert "\n\n" in result  # Blank line separator between chunks
 
 
@@ -689,7 +712,11 @@ class TestTranscribeSmallFile:
         with patch("vtt.main.OpenAI") as mock_openai:
             mock_client = MagicMock()
             mock_openai.return_value = mock_client
-            mock_client.audio.transcriptions.create.return_value = cast("TranscriptionVerbose", "Full transcript")  # type: ignore[arg-type]
+            mock_client.audio.transcriptions.create.return_value = cast(
+                # type: ignore[arg-type]
+                "TranscriptionVerbose",
+                "Full transcript",
+            )
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 video_path = Path(tmpdir) / "video.mp4"
@@ -698,7 +725,7 @@ class TestTranscribeSmallFile:
                 audio_path.write_text("x" * 1024)  # 1KB file
 
                 with (
-                    patch.object(VideoTranscriber, "validate_video_file", return_value=video_path),
+                    patch.object(VideoTranscriber, "validate_input_file", return_value=video_path),
                     patch.object(VideoTranscriber, "extract_audio"),
                     patch("builtins.print"),
                 ):
@@ -733,7 +760,7 @@ class TestTranscribeLargeFile:
                 audio_path.write_text("x" * (30 * 1024 * 1024))
 
                 with (
-                    patch.object(VideoTranscriber, "validate_video_file", return_value=video_path),
+                    patch.object(VideoTranscriber, "validate_input_file", return_value=video_path),
                     patch.object(VideoTranscriber, "extract_audio"),
                     patch.object(VideoTranscriber, "get_audio_duration", return_value=600.0),
                     patch.object(VideoTranscriber, "extract_audio_chunk") as mock_extract_chunk,
@@ -1162,7 +1189,7 @@ class TestIntegrationFullWorkflow:
                         str(transcript_path),
                     ],
                 ),
-                patch.object(VideoTranscriber, "validate_video_file", return_value=video_path),
+                patch.object(VideoTranscriber, "validate_input_file", return_value=video_path),
                 patch.object(VideoTranscriber, "extract_audio"),
                 patch.object(VideoTranscriber, "transcribe_audio_file", return_value="Final transcript"),
                 patch("builtins.print"),
@@ -1403,7 +1430,7 @@ def test_main_guard_executes_with_mocked_deps(tmp_path: Path, monkeypatch: pytes
     import sys
     import types
 
-    # Given a dummy video file so validate_video_file passes
+    # Given a dummy video file so validate_input_file passes
     video = tmp_path / "video.mp4"
     video.write_bytes(b"mp4")
 
@@ -1446,9 +1473,12 @@ def test_main_guard_executes_with_mocked_deps(tmp_path: Path, monkeypatch: pytes
     openai_mod.OpenAI = DummyClient  # type: ignore[attr-defined]
 
     # And: insert fake modules into sys.modules so runpy will use them
-    monkeypatch.setitem(sys.modules, "moviepy.video.io.VideoFileClip", moviepy_vfc)  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "moviepy.audio.io.AudioFileClip", moviepy_afc)  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "openai", openai_mod)  # type: ignore[attr-defined]
+    # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "moviepy.video.io.VideoFileClip", moviepy_vfc)
+    # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "moviepy.audio.io.AudioFileClip", moviepy_afc)
+    # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "openai", openai_mod)
 
     # Run main.py as a __main__ module to hit the if __name__ == "__main__" guard
     monkeypatch.chdir(str(tmp_path))


### PR DESCRIPTION
# Summary
Rename CLI/user-facing references from video_file to input_file and update README examples/docs to reflect that the tool accepts both video and audio inputs. This is a purely cosmetic/clarity change (help text, variable names and docs) to reduce confusion about input types.

#Files changed
vtt/main.py (CLI arg/help and internal identifier renames), README.md (examples and CLI docs), tests updated where appropriate to use input_* naming (kept some video_* names in tests where that context remained clearer).

# Rationale
Clarifies that the CLI accepts audio files directly and avoids misleading “video-only” terminology.