### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/JLCodeSource/vtt-transcribe/security/code-scanning/1](https://github.com/JLCodeSource/vtt-transcribe/security/code-scanning/1)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or the specific job so that the `GITHUB_TOKEN` has only the access it needs. For a typical CI job that only checks out code and runs tests, `contents: read` is sufficient, and no write scopes are required.

The best targeted fix here is to add a `permissions` block at the root of the workflow (top level, alongside `name:` and `on:`). This will apply to all jobs in the workflow, including `build`, and avoids changing any existing behavior other than tightening the token’s scope. Based on the current steps (checkout, setup Python, install ffmpeg, install dependencies via `make`, lint, test), no job needs to write to the repository or interact with issues/PRs, so `contents: read` is adequate. Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: CI` and `on:` keys. No additional methods, imports, or definitions are required, since this is just a declarative YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
