### PR TITLE
docs: Document blocking test isolation issue

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,12 @@ A Python CLI tool (`vtt-transcribe`) that extracts audio from video files and tr
 **Status**: Beta release with diarization support, published to PyPI  
 **Install**: `pip install vtt-transcribe`
 
+**⚠️ BLOCKING ISSUE**: Test isolation broken after stdin mode implementation (vtt-transcribe-ufr)
+- 31 tests failing due to missing `sys.stdin.isatty()` mocks
+- Affects: test_cli.py, test_handlers.py, test_main.py, test_diarization.py, test_transcriber.py
+- **DO NOT merge any PR until this is resolved**
+- Fix in progress on branch: `fix/test-isolation-stdin-mode`
+
 ## Development Workflow Requirements
 
 **CRITICAL**: This project follows strict development standards. All work must adhere to:


### PR DESCRIPTION
## Issue
**vtt-transcribe-ufr** - Test isolation broken after stdin mode implementation

## Problem
After implementing stdin mode detection in main(), 31 existing tests fail because they don't mock `sys.stdin.isatty()`. This causes stdin mode to activate unexpectedly in test environments.

## Affected Files
- `tests/test_cli.py` - 11 failures
- `tests/test_handlers.py` - 6 failures  
- `tests/test_main.py` - 3 failures
- `tests/test_diarization.py` - 2 failures
- `tests/test_stdin_mode.py` - 8 failures
- `tests/test_transcriber.py` - 1 failure

## Impact
- **All PR merges blocked** until this is resolved
- Updated copilot-instructions.md to document the blocker
- Priority: P1

## Next Steps
After this PR is merged, a follow-up PR will fix all 31 failing tests by adding proper stdin mocks.

## Context
This documents the issue but doesn't fix it. The fix will come in a separate PR that adds `patch('sys.stdin')` with `isatty.return_value=True` to all affected tests.