### PR TITLE
fix(docker): install torchaudio from CPU-only PyTorch index

### DIFF
--- a/Dockerfile.diarization
+++ b/Dockerfile.diarization
@@ -24,9 +24,10 @@ COPY pyproject.toml README.md ./
 RUN uv venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Install PyTorch first in its own layer (~2.5GB)
+# Install PyTorch + torchaudio (CPU-only) in their own layer (~2.5GB)
 # This keeps individual layers under Docker Hub's per-blob size limit
-RUN uv pip install torch==2.8.0 --index-url https://download.pytorch.org/whl/cpu
+# Both must come from the CPU index to avoid CUDA dependency (libtorch_cuda.so)
+RUN uv pip install torch==2.8.0 torchaudio --index-url https://download.pytorch.org/whl/cpu
 
 # Install remaining diarization dependencies in a separate layer
 RUN uv pip install pyannote.audio


### PR DESCRIPTION
## Problem
`pyannote.audio` pulls `torchaudio` from regular PyPI, which ships
the CUDA build requiring `libtorch_cuda.so`. This causes an OSError
at import time in the CPU-only diarization image.

## Fix
Explicitly install `torchaudio` alongside `torch` from the CPU-only
index (`https://download.pytorch.org/whl/cpu`) so the lightweight
CPU variant is used.

Also splits the runtime COPY into sub-directories to keep per-layer
blob sizes under Docker Hub's limit.

## Verified
- Local build succeeds
- `import pyannote.audio` works
- `torch.__version__ == '2.8.0+cpu'`, `torchaudio.__version__ == '2.8.0+cpu'`
- BATS docker diarization test passes