### PR TITLE
fix: ensure saved transcripts end with trailing newline

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -28,7 +28,7 @@ class TestSaveTranscript:
 
         expected_path = tmp_path / "transcript.txt"
         assert expected_path.exists()
-        assert expected_path.read_text() == transcript
+        assert expected_path.read_text() == transcript + "\n"
 
     def test_save_transcript_preserves_txt_extension(self, tmp_path: Path) -> None:
         """Test that save_transcript preserves .txt extension."""
@@ -38,7 +38,28 @@ class TestSaveTranscript:
         save_transcript(output_path, transcript)
 
         assert output_path.exists()
-        assert output_path.read_text() == transcript
+        assert output_path.read_text() == transcript + "\n"
+
+    def test_save_transcript_ensures_trailing_newline(self, tmp_path: Path) -> None:
+        """Test that save_transcript ensures file ends with a newline."""
+        output_path = tmp_path / "transcript.txt"
+        transcript = "[00:00 - 00:05] Hello world\n[00:05 - 00:10] Goodbye"
+
+        save_transcript(output_path, transcript)
+
+        content = output_path.read_text()
+        assert content.endswith("\n"), "Saved transcript must end with a newline"
+
+    def test_save_transcript_no_double_newline(self, tmp_path: Path) -> None:
+        """Test that save_transcript doesn't double a trailing newline."""
+        output_path = tmp_path / "transcript.txt"
+        transcript = "Already has newline\n"
+
+        save_transcript(output_path, transcript)
+
+        content = output_path.read_text()
+        assert content == "Already has newline\n"
+        assert not content.endswith("\n\n")
 
 
 class TestDisplayResult:

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -177,7 +177,7 @@ class TestTranscriptFileExtensionHandling:
 
         # Then file is saved with .txt extension automatically added
         assert Path(tmp_path, "mytranscript.txt").exists()
-        assert Path(tmp_path, "mytranscript.txt").read_text() == transcript
+        assert Path(tmp_path, "mytranscript.txt").read_text() == transcript + "\n"
 
     def test_save_transcript_with_different_extension(self, tmp_path: Path) -> None:
         """Should replace custom extension with .txt."""
@@ -191,7 +191,7 @@ class TestTranscriptFileExtensionHandling:
 
         # Then extension is replaced with .txt
         assert Path(tmp_path, "mytranscript.txt").exists()
-        assert Path(tmp_path, "mytranscript.txt").read_text() == transcript
+        assert Path(tmp_path, "mytranscript.txt").read_text() == transcript + "\n"
         # Original .text file should not exist
         assert not output_path.exists()
 
@@ -207,7 +207,7 @@ class TestTranscriptFileExtensionHandling:
 
         # Then file is saved with .txt extension added
         assert Path(tmp_path, "output_file.txt").exists()
-        assert Path(tmp_path, "output_file.txt").read_text() == transcript
+        assert Path(tmp_path, "output_file.txt").read_text() == transcript + "\n"
 
 
 class TestExtractAudio:
@@ -817,7 +817,7 @@ class TestSaveTranscript:
 
         # Then file is created with correct content
         assert output_path.exists()
-        assert output_path.read_text() == transcript
+        assert output_path.read_text() == transcript + "\n"
 
     def test_save_transcript_creates_directory(self, tmp_path: Path) -> None:
         """Should work with nested paths."""
@@ -831,7 +831,7 @@ class TestSaveTranscript:
             save_transcript(output_path, transcript)
 
         # Then file is created in nested directory with correct content
-        assert output_path.read_text() == transcript
+        assert output_path.read_text() == transcript + "\n"
 
 
 class TestDisplayResult:
@@ -1197,4 +1197,4 @@ class TestEdgeCases:
             save_transcript(output_path, transcript)
 
         # Then verify expected behavior
-        assert output_path.read_text() == transcript
+        assert output_path.read_text() == transcript + "\n"

--- a/vtt_transcribe/handlers.py
+++ b/vtt_transcribe/handlers.py
@@ -20,10 +20,12 @@ DIARIZATION_DEPS_ERROR_MSG = (
 
 
 def save_transcript(output_path: Path, transcript: str) -> None:
-    """Save transcript to a file, ensuring .txt extension."""
+    """Save transcript to a file, ensuring .txt extension and trailing newline."""
     # Ensure output path has .txt extension
     if output_path.suffix.lower() != ".txt":
         output_path = output_path.with_suffix(TRANSCRIPT_EXTENSION)
+    if not transcript.endswith("\n"):
+        transcript += "\n"
     output_path.write_text(transcript)
     print(f"\nTranscript saved to: {output_path}")
 


### PR DESCRIPTION
## Problem

When using `--save-transcript`, the saved file doesn't always end with a newline character. This is because `"\n".join(lines)` in the transcriber/diarization code produces strings without a trailing newline, and `save_transcript()` wrote them as-is.

## Fix

`save_transcript()` in `handlers.py` now appends `\n` if the transcript doesn't already end with one. This ensures all saved transcript files are properly terminated.

## Tests

- **`test_save_transcript_ensures_trailing_newline`** — verifies newline is appended when missing
- **`test_save_transcript_no_double_newline`** — verifies no double newline when one already exists
- Updated 8 existing assertions to expect the trailing newline

**282 passed, 0 failed.**