### PR TITLE
test: achieve 100% coverage on vtt_transcribe package

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -730,6 +730,21 @@ class TestVideoFormatDetection:
         data = b"short"
         assert _detect_format_from_data(data) == ".mp3"
 
+    def test_detect_format_with_empty_data_raises(self) -> None:
+        """Test that empty data raises ValueError."""
+        from vtt_transcribe.main import _detect_format_from_data
+
+        with pytest.raises(ValueError, match="Cannot detect format from empty data stream"):
+            _detect_format_from_data(b"")
+
+    def test_detect_ftyp_with_unknown_brand_defaults_to_mp4(self) -> None:
+        """Test that ftyp box with non-standard brand still returns .mp4."""
+        from vtt_transcribe.main import _detect_format_from_data
+
+        # ftyp box with an unusual brand that doesn't match any known prefix
+        data = b"\x00\x00\x00\x20ftypXXXX\x00\x00\x00\x00" + b"\x00" * 100
+        assert _detect_format_from_data(data) == ".mp4"
+
 
 class TestStdinTempFileCreation:
     """Test stdin temp file creation with format detection."""

--- a/vtt_transcribe/handlers.py
+++ b/vtt_transcribe/handlers.py
@@ -272,7 +272,7 @@ def _lazy_import_diarization() -> tuple:
         elif is_missing_dependency:
             # Missing dependency within the diarization module (e.g., torch, pyannote.audio)
             raise ImportError(DIARIZATION_DEPS_ERROR_MSG) from e
-        else:
+        else:  # pragma: no cover
             # Should never reach here, but re-raise just in case
             raise
     return SpeakerDiarizer, format_diarization_output, get_unique_speakers, get_speaker_context_lines

--- a/vtt_transcribe/main.py
+++ b/vtt_transcribe/main.py
@@ -232,5 +232,5 @@ def main() -> None:
             temp_file_path.unlink()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
## Summary

Closes the remaining coverage gaps in the `vtt_transcribe/` package, bringing all 11 source files to **100% coverage**.

### Changes

**New tests** (in `tests/test_main.py`):
- `test_detect_format_with_empty_data_raises` — covers `_detect_format_from_data()` with empty input (L120-121)
- `test_detect_ftyp_with_unknown_brand_defaults_to_mp4` — covers ftyp box with non-standard brand fallback (L133)

**Pragma exclusions** (structurally untestable lines):
- `main.py` L236: `if __name__ == "__main__"` guard — standard Python convention, never hit by pytest
- `handlers.py` L277: defensive `raise` after exhaustive if/elif/else — unreachable by design

### Results
- **284 passed**, 7 skipped
- All lint/mypy checks pass
- All 11 files in `vtt_transcribe/` at **100%** coverage