### PR TITLE
feat(cgu.2): Implement file upload endpoint with validation

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 """Tests for FastAPI application."""
 
+import io
+
 from fastapi.testclient import TestClient
 
 
@@ -36,3 +38,85 @@ def test_openapi_json_schema() -> None:
     assert response.json()["info"]["title"] == "VTT Transcribe API"
     assert "paths" in response.json()
     assert "/health" in response.json()["paths"]
+
+
+def test_upload_audio_file_success() -> None:
+    """Test successful audio file upload."""
+    from vtt_transcribe.api import app
+
+    client = TestClient(app)
+
+    # Create a fake MP3 file
+    fake_mp3_content = b"fake mp3 content for testing"
+    files = {"file": ("test.mp3", io.BytesIO(fake_mp3_content), "audio/mpeg")}
+
+    response = client.post("/api/v1/transcribe", files=files)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "job_id" in data
+    assert "status" in data
+    assert data["status"] == "pending"
+
+
+def test_upload_video_file_success() -> None:
+    """Test successful video file upload."""
+    from vtt_transcribe.api import app
+
+    client = TestClient(app)
+
+    # Create a fake MP4 file
+    fake_mp4_content = b"fake mp4 content for testing"
+    files = {"file": ("test.mp4", io.BytesIO(fake_mp4_content), "video/mp4")}
+
+    response = client.post("/api/v1/transcribe", files=files)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "job_id" in data
+    assert "status" in data
+
+
+def test_upload_invalid_file_type() -> None:
+    """Test rejection of unsupported file type."""
+    from vtt_transcribe.api import app
+
+    client = TestClient(app)
+
+    # Create a fake text file (unsupported)
+    fake_content = b"not a valid audio/video file"
+    files = {"file": ("test.txt", io.BytesIO(fake_content), "text/plain")}
+
+    response = client.post("/api/v1/transcribe", files=files)
+
+    assert response.status_code == 400
+    assert "detail" in response.json()
+    assert "Unsupported file type" in response.json()["detail"]
+
+
+def test_upload_without_file() -> None:
+    """Test endpoint requires file upload."""
+    from vtt_transcribe.api import app
+
+    client = TestClient(app)
+
+    response = client.post("/api/v1/transcribe")
+
+    assert response.status_code == 422  # Unprocessable Entity
+
+
+def test_upload_file_too_large() -> None:
+    """Test rejection of files exceeding size limit."""
+    from vtt_transcribe.api import app
+
+    client = TestClient(app)
+
+    # Create a file larger than typical limits (e.g., 100MB)
+    # For testing, we'll simulate this with metadata
+    large_content = b"x" * (101 * 1024 * 1024)  # 101MB
+    files = {"file": ("large.mp3", io.BytesIO(large_content), "audio/mpeg")}
+
+    response = client.post("/api/v1/transcribe", files=files)
+
+    # Should either reject immediately or handle gracefully
+    assert response.status_code in [400, 413]  # Bad Request or Payload Too Large

--- a/vtt_transcribe/api.py
+++ b/vtt_transcribe/api.py
@@ -1,6 +1,20 @@
 """FastAPI application for VTT Transcribe."""
 
-from fastapi import FastAPI
+import uuid
+from pathlib import Path
+from tempfile import mkdtemp
+from typing import Annotated
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+
+# Maximum file size: 100MB
+MAX_FILE_SIZE = 100 * 1024 * 1024
+
+# Supported file extensions
+SUPPORTED_EXTENSIONS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg"}
+
+# Temporary upload directory
+UPLOAD_DIR = Path(mkdtemp(prefix="vtt_transcribe_"))
 
 app = FastAPI(
     title="VTT Transcribe API",
@@ -13,3 +27,50 @@ app = FastAPI(
 async def health() -> dict[str, str]:
     """Health check endpoint."""
     return {"status": "ok"}
+
+
+@app.post("/api/v1/transcribe")
+async def upload_file(
+    file: Annotated[UploadFile, File(description="Audio or video file to transcribe")],
+) -> dict[str, str]:
+    """Upload audio/video file for transcription.
+
+    Args:
+        file: Uploaded audio or video file
+
+    Returns:
+        Job ID and status
+
+    Raises:
+        HTTPException: If file type is unsupported or file is too large
+    """
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No filename provided")
+
+    # Validate file extension
+    file_ext = Path(file.filename).suffix.lower()
+    if file_ext not in SUPPORTED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type: {file_ext}. Supported types: {', '.join(sorted(SUPPORTED_EXTENSIONS))}",
+        )
+
+    # Read and validate file size
+    content = await file.read()
+    if len(content) > MAX_FILE_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large: {len(content)} bytes. Maximum size: {MAX_FILE_SIZE} bytes",
+        )
+
+    # Generate unique job ID
+    job_id = str(uuid.uuid4())
+
+    # Save file to temporary location
+    upload_path = UPLOAD_DIR / f"{job_id}{file_ext}"
+    upload_path.write_bytes(content)
+
+    return {
+        "job_id": job_id,
+        "status": "pending",
+    }


### PR DESCRIPTION
## Summary
Implements task vtt-transcribe-cgu.2: POST /api/v1/transcribe endpoint for multipart file uploads.

## Changes
- POST /api/v1/transcribe endpoint accepting multipart form data
- File type validation (supports .mp3, .mp4, .wav, .ogg, .m4a, .webm, .mpeg, .mpga)
- 100MB file size limit enforcement (HTTP 413 for oversized files)
- UUID-based job ID generation
- Temporary file storage for processing
- Comprehensive tests for success and error cases

## Testing
- 252 tests passing (5 new tests added)
- Validates file types, sizes, and presence
- Tests for error handling (unsupported types, missing files, oversized files)
- Linting and type checking passing

## Dependencies
- Builds on PR #219 (FastAPI foundation)

## Related
Closes: vtt-transcribe-cgu.2
Part of: v0.4.0 FastAPI Backend epic