### PR TITLE
feat(T099): Background Transcription Processing & Job Status

### DIFF
--- a/vtt_transcribe/api.py
+++ b/vtt_transcribe/api.py
@@ -1,11 +1,15 @@
 """FastAPI application for VTT Transcribe."""
 
+import contextlib
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Annotated
+from typing import Annotated, Any
 
-from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, UploadFile
+
+from vtt_transcribe.transcriber import VideoTranscriber
 
 # Maximum file size: 100MB
 MAX_FILE_SIZE = 100 * 1024 * 1024
@@ -16,11 +20,39 @@ SUPPORTED_EXTENSIONS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm
 # Temporary upload directory
 UPLOAD_DIR = Path(mkdtemp(prefix="vtt_transcribe_"))
 
+# In-memory job storage (will be replaced with database)
+jobs: dict[str, dict[str, Any]] = {}
+
 app = FastAPI(
     title="VTT Transcribe API",
     description="Transcribe video and audio files to text using OpenAI Whisper with optional speaker diarization",
     version="0.4.0",
 )
+
+
+async def process_transcription(job_id: str, file_path: Path, api_key: str) -> None:
+    """Background task to process transcription."""
+    try:
+        jobs[job_id]["status"] = "processing"
+
+        # Transcribe the file
+        transcriber = VideoTranscriber(api_key)
+        transcript_text = transcriber.transcribe(file_path, keep_audio=False)
+
+        # Update job with results
+        jobs[job_id]["status"] = "completed"
+        jobs[job_id]["transcript"] = {"text": transcript_text}
+        jobs[job_id]["completed_at"] = datetime.now(UTC).isoformat()
+
+    except Exception as e:
+        jobs[job_id]["status"] = "failed"
+        jobs[job_id]["error"] = str(e)
+        jobs[job_id]["failed_at"] = datetime.now(UTC).isoformat()
+
+    finally:
+        # Clean up temporary file
+        with contextlib.suppress(Exception):
+            file_path.unlink(missing_ok=True)  # noqa: ASYNC240
 
 
 @app.get("/health")
@@ -31,12 +63,16 @@ async def health() -> dict[str, str]:
 
 @app.post("/api/v1/transcribe")
 async def upload_file(
+    background_tasks: BackgroundTasks,
     file: Annotated[UploadFile, File(description="Audio or video file to transcribe")],
+    api_key: str | None = Form(None),
 ) -> dict[str, str]:
     """Upload audio/video file for transcription.
 
     Args:
+        background_tasks: FastAPI background tasks
         file: Uploaded audio or video file
+        api_key: Optional OpenAI API key for background transcription
 
     Returns:
         Job ID and status
@@ -70,7 +106,38 @@ async def upload_file(
     upload_path = UPLOAD_DIR / f"{job_id}{file_ext}"
     upload_path.write_bytes(content)
 
+    # Store job metadata
+    jobs[job_id] = {
+        "job_id": job_id,
+        "status": "pending",
+        "filename": file.filename,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+
+    # If API key provided, queue background transcription
+    if api_key:
+        background_tasks.add_task(process_transcription, job_id, upload_path, api_key)
+
     return {
         "job_id": job_id,
         "status": "pending",
     }
+
+
+@app.get("/api/v1/jobs/{job_id}")
+async def get_job_status(job_id: str) -> dict[str, Any]:
+    """Get the status of a transcription job.
+
+    Args:
+        job_id: The unique job identifier
+
+    Returns:
+        Job status and metadata
+
+    Raises:
+        HTTPException: If job not found
+    """
+    if job_id not in jobs:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    return jobs[job_id]


### PR DESCRIPTION
## Summary
Adds background transcription processing and job status tracking to the FastAPI backend.

## Changes
- ✅ Add in-memory job storage for tracking transcription jobs
- ✅ Add **GET /api/v1/jobs/{job_id}** endpoint to check job status
- ✅ Add optional `api_key` Form parameter to POST /api/v1/transcribe
- ✅ Integrate existing `VideoTranscriber` for actual transcription
- ✅ Background task processing with FastAPI BackgroundTasks
- ✅ Job lifecycle: `pending` → `processing` → `completed` (with transcript) or `failed` (with error)
- ✅ Automatic cleanup of temporary files after processing
- ✅ Comprehensive test coverage (10 API tests, all passing)

## API Usage

### Upload file without API key (file storage only):
```bash
curl -X POST http://localhost:8000/api/v1/transcribe \
  -F "file=@test.mp3"
# Returns: {"job_id": "...", "status": "pending"}
```

### Upload file with API key (triggers background transcription):
```bash
curl -X POST http://localhost:8000/api/v1/transcribe \
  -F "file=@test.mp3" \
  -F "api_key=sk-..."
# Returns: {"job_id": "...", "status": "pending"}
```

### Check job status:
```bash
curl http://localhost:8000/api/v1/jobs/{job_id}
# Returns: {"job_id": "...", "status": "completed", "transcript": {"text": "..."}, ...}
```

## Testing
- All 10 API tests passing
- Lint and mypy checks pass
- Follows TDD Red-Green-Refactor workflow

## Implementation Details
- Optional `api_key` parameter preserves backward compatibility
- Background tasks run after response is sent
- Exception handling captures failures in job status
- Uses `contextlib.suppress` for best-effort file cleanup
- Builds on existing API structure from #219, #220, #223

## Next Steps
- [ ] Add database persistence (replace in-memory dict)
- [ ] Add WebSocket support for real-time progress
- [ ] Add authentication middleware
- [ ] Add job expiration policies
- [ ] Add diarization support via API

## Related
- Builds on: #219, #220, #223 (already merged)
- Supersedes closed PRs: #218, #221, #224
- Roadmap: Version 0.4.0 (docs/ROADMAP.md)