### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,8 @@ jobs:
   update-dockerhub-description:
     name: Update Docker Hub Description
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Run on release, push to main (docs/DOCKER_HUB.md changes), or manual dispatch
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/JLCodeSource/vtt-transcribe/security/code-scanning/3](https://github.com/JLCodeSource/vtt-transcribe/security/code-scanning/3)

In general, fix this by explicitly defining a `permissions` block that restricts `GITHUB_TOKEN` to the minimum needed. This can be defined at the workflow root to apply to all jobs, or at the job level for specific jobs that need different scopes. For the `update-dockerhub-description` job, it only needs to read repository contents (for `docs/DOCKER_HUB.md` and description), so `contents: read` is sufficient.

The best minimal change without altering existing functionality is:

- Add a `permissions` block under the `update-dockerhub-description` job, at the same indentation level as `runs-on:`.
- Set `contents: read` (no write or additional scopes are required for the shown steps).
- Leave the already-correct `permissions` block on the `publish-base` job unchanged.
- Do not modify any other jobs not shown in detail.

Concretely, in `.github/workflows/docker-publish.yml`, between lines 28 and 29 (after `runs-on: ubuntu-latest` for the `update-dockerhub-description` job), insert:

```yaml
    permissions:
      contents: read
```

No imports or additional methods are needed, since this is purely a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
