### PR TITLE
fix: Update Svelte 5 event syntax for frontend components

### DIFF
--- a/frontend/src/components/FileUpload.svelte
+++ b/frontend/src/components/FileUpload.svelte
@@ -141,9 +141,9 @@
     class="dropzone"
     class:dragging={isDragging}
     class:has-file={selectedFile}
-    on:dragover={handleDragOver}
-    on:dragleave={handleDragLeave}
-    on:drop={handleDrop}
+    ondragover={handleDragOver}
+    ondragleave={handleDragLeave}
+    ondrop={handleDrop}
     role="region"
     aria-label="File upload dropzone"
   >
@@ -163,7 +163,7 @@
           <button
             type="button"
             class="primary"
-            on:click={() => document.getElementById('file-input')?.click()}
+            onclick={() => document.getElementById('file-input')?.click()}
           >
             Choose File
           </button>
@@ -172,7 +172,7 @@
           id="file-input"
           type="file"
           accept="video/*,audio/*"
-          on:change={handleFileSelect}
+          onchange={handleFileSelect}
           style="display: none;"
         />
         <p class="hint">Supports MP4, AVI, MOV, MP3, WAV, and more</p>
@@ -191,7 +191,7 @@
           <h4>{selectedFile.name}</h4>
           <p>{(selectedFile.size / 1024 / 1024).toFixed(2)} MB</p>
         </div>
-        <button type="button" class="clear-btn" on:click={clearFile} disabled={isUploading}>
+        <button type="button" class="clear-btn" onclick={clearFile} disabled={isUploading}>
           ✕
         </button>
       </div>
@@ -259,7 +259,7 @@
         </select>
       </label>
 
-      <button type="button" class="primary upload-btn" on:click={handleUpload} disabled={isUploading}>
+      <button type="button" class="primary upload-btn" onclick={handleUpload} disabled={isUploading}>
         {isUploading ? 'Uploading...' : 'Start Transcription'}
       </button>
     </div>

--- a/frontend/src/components/TranscriptViewer.svelte
+++ b/frontend/src/components/TranscriptViewer.svelte
@@ -67,16 +67,16 @@
   <div class="transcript-header">
     <h2>📄 Transcript</h2>
     <div class="header-actions">
-      <button type="button" class="secondary" on:click={() => downloadTranscript('txt')}>
+      <button type="button" class="secondary" onclick={() => downloadTranscript('txt')}>
         Download TXT
       </button>
-      <button type="button" class="secondary" on:click={() => downloadTranscript('vtt')}>
+      <button type="button" class="secondary" onclick={() => downloadTranscript('vtt')}>
         Download VTT
       </button>
-      <button type="button" class="secondary" on:click={() => downloadTranscript('srt')}>
+      <button type="button" class="secondary" onclick={() => downloadTranscript('srt')}>
         Download SRT
       </button>
-      <button type="button" class="secondary" on:click={onreset}>New Transcription</button>
+      <button type="button" class="secondary" onclick={onreset}>New Transcription</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
Fixes Svelte 5 deprecated event handler syntax in frontend components.

## Changes
- Converted all  → 
- Converted all  →   
- Converted all  → 

## Files Changed
- 
- 

## Why
Svelte 5 deprecated the  directive syntax in favor of the new event attribute syntax. The old syntax causes build warnings and prevented the frontend from rendering properly.

## Testing
- ✅ Build completes without Svelte deprecation warnings
- ✅ All event handlers work correctly (file upload, drag/drop, buttons)
- ✅ Linting and formatting pass

## Related
Separate from PR #270 (docker-compose/secrets) - this focuses solely on frontend Svelte 5 compatibility.